### PR TITLE
Msgpack 0 5 4

### DIFF
--- a/euxfel_karabo_bridge/client.py
+++ b/euxfel_karabo_bridge/client.py
@@ -65,7 +65,7 @@ class Client:
             raise NotImplementedError('socket is not supported:', str(sock))
 
         if ser == 'msgpack':
-            self._deserializer = partial(msgpack.loads, encoding='utf-8')
+            self._deserializer = partial(msgpack.loads, raw=False)
         elif ser == 'pickle':
             self._deserializer = pickle.loads
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-msgpack-python==0.4.6
+msgpack>=0.5.4
 msgpack-numpy
 numpy
 pyzmq>=17.0.0


### PR DESCRIPTION
update to the new package name. msgpack-python >> msgpack.

changes:
utf-8 is the default encoding
'raw' option has to be explicit to distinguish between string and bytestring (will change in later release of the package).