### PR TITLE
Enable generating multisource messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.egg-info/
 /build/
 /dist/
+.idea

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -45,7 +45,7 @@ _SHAPE = (_PULSES, _MODULES, _MOD_X, _MOD_Y)
 # _SHAPE = (_PULSES, _MODULES, _MOD_X, _MOD_Y)
 
 
-def gen_combined_detector_data(source, tid_counter, corrected=False, ns=1):
+def gen_combined_detector_data(source, tid_counter, corrected=False, nsources=1):
     gen = {source: {}}
 
     # metadata
@@ -127,8 +127,8 @@ def gen_combined_detector_data(source, tid_counter, corrected=False, ns=1):
     gen[source]['header.reserved'] = reserved
     gen[source]['header.trainId'] = tid_counter
 
-    if ns > 1:
-        for i in range(ns):
+    if nsources > 1:
+        for i in range(nsources):
             src = source + "-" + str(i+1)
             gen[src] = copy.deepcopy(gen[source])
             gen[src]['metadata.source'] = src
@@ -138,14 +138,14 @@ def gen_combined_detector_data(source, tid_counter, corrected=False, ns=1):
     return gen
 
 
-def generate(source, corrected, queue, ns):
+def generate(source, corrected, queue, nsources):
     tid_counter = 10000000000
     try:
         while True:
             if len(queue) < queue.maxlen:
                 data = gen_combined_detector_data(source, tid_counter,
                                                   corrected=corrected,
-                                                  ns=ns)
+                                                  nsources=nsources)
                 tid_counter += 1
                 queue.append(data)
                 print('Server : buffered train:',
@@ -208,7 +208,7 @@ def containize(data, ser, ser_func, vers):
 
 
 def start_gen(port, ser='msgpack', version='latest', detector='AGIPD',
-              corrected=True, ns=1):
+              corrected=True, nsources=1):
     """"Karabo bridge server simulation.
 
     Simulate a Karabo Bridge server and send random data from a detector,
@@ -226,7 +226,7 @@ def start_gen(port, ser='msgpack', version='latest', detector='AGIPD',
         The data format to send, default is AGIPD detector.
     corrected: bool, optional
         Generate corrected data output if True, else RAW. Default is True.
-    ns: int, optional
+    nsources: int, optional
         Number of sources.
     """
     context = zmq.Context()
@@ -245,7 +245,7 @@ def start_gen(port, ser='msgpack', version='latest', detector='AGIPD',
 
     queue = deque(maxlen=10)
 
-    t = Thread(target=generate, args=(source, corrected, queue, ns, ))
+    t = Thread(target=generate, args=(source, corrected, queue, nsources, ))
     t.daemon = True
     t.start()
 

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -15,6 +15,7 @@ from functools import partial
 import pickle
 from time import sleep, time
 from threading import Thread
+import copy
 
 import msgpack
 import msgpack_numpy
@@ -44,7 +45,7 @@ _SHAPE = (_PULSES, _MODULES, _MOD_X, _MOD_Y)
 # _SHAPE = (_PULSES, _MODULES, _MOD_X, _MOD_Y)
 
 
-def gen_combined_detector_data(source, tid_counter, corrected=False):
+def gen_combined_detector_data(source, tid_counter, corrected=False, ns=1):
     gen = {source: {}}
 
     # metadata
@@ -126,20 +127,29 @@ def gen_combined_detector_data(source, tid_counter, corrected=False):
     gen[source]['header.reserved'] = reserved
     gen[source]['header.trainId'] = tid_counter
 
+    if ns > 1:
+        for i in range(ns):
+            src = source + "-" + str(i+1)
+            gen[src] = copy.deepcopy(gen[source])
+            gen[src]['metadata.source'] = src
+
+        del gen[source]
+
     return gen
 
 
-def generate(source, corrected, queue):
+def generate(source, corrected, queue, ns):
     tid_counter = 10000000000
     try:
         while True:
             if len(queue) < queue.maxlen:
                 data = gen_combined_detector_data(source, tid_counter,
-                                                  corrected=corrected)
+                                                  corrected=corrected,
+                                                  ns=ns)
                 tid_counter += 1
                 queue.append(data)
                 print('Server : buffered train:',
-                      data[source]['metadata.timestamp.tid'])
+                      data[list(data.keys())[0]]['metadata.timestamp.tid'])
             else:
                 sleep(0.1)
     except KeyboardInterrupt:
@@ -198,7 +208,7 @@ def containize(data, ser, ser_func, vers):
 
 
 def start_gen(port, ser='msgpack', version='latest', detector='AGIPD',
-              corrected=True):
+              corrected=True, ns=1):
     """"Karabo bridge server simulation.
 
     Simulate a Karabo Bridge server and send random data from a detector,
@@ -216,6 +226,8 @@ def start_gen(port, ser='msgpack', version='latest', detector='AGIPD',
         The data format to send, default is AGIPD detector.
     corrected: bool, optional
         Generate corrected data output if True, else RAW. Default is True.
+    ns: int, optional
+        Number of sources.
     """
     context = zmq.Context()
     socket = context.socket(zmq.REP)
@@ -233,7 +245,7 @@ def start_gen(port, ser='msgpack', version='latest', detector='AGIPD',
 
     queue = deque(maxlen=10)
 
-    t = Thread(target=generate, args=(source, corrected, queue,))
+    t = Thread(target=generate, args=(source, corrected, queue, ns, ))
     t.daemon = True
     t.start()
 


### PR DESCRIPTION
To generate multi-source data, use start_gen(port, ns=2). The source names will be the default source name appended by "-1", "-2", e.g. "SPB_DET_AGIPD1M-1/DET/detector-1", "SPB_DET_AGIPD1M-1/DET/detector-2".

The default start_gen(port) behaves the same as before.

