### PR TITLE
Use zero-copy send in simulator and client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 install:
   - pip install -e .[test]
-  - pip install codecov
+  - pip install --upgrade codecov pytest
 
 script:
   - py.test -v --cov karabo_bridge

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
   - pip install codecov
 
 script:
-  - py.test --cov karabo_bridge
+  - py.test -v --cov karabo_bridge
 
 after_success: codecov

--- a/karabo_bridge/cli/simulation.py
+++ b/karabo_bridge/cli/simulation.py
@@ -11,7 +11,7 @@ def main(argv=None):
         'port', help="TCP port the server will bind"
     )
     ap.add_argument(
-        '-d', '--detector', default='AGIPD', choices=['AGIPD', 'LPD'],
+        '-d', '--detector', default='AGIPD', choices=['AGIPD', 'AGIPDModule', 'LPD'],
         help="Which kind of detector to simulate (default: AGIPD)"
     )
     ap.add_argument(

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -45,6 +45,9 @@ class Detector:
         if detector == 'AGIPD':
             source = source or 'SPB_DET_AGIPD1M-1/DET/detector'
             return AGIPD(source, corr=corr, gen=gen)
+        elif detector == 'AGIPDModule':
+            source = source or 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'
+            return AGIPDModule(source, corr=corr, gen=gen)
         elif detector == 'LPD':
             source = source or 'FXE_DET_LPD1M-1/DET/detector'
             return LPD(source, corr=corr, gen=gen)
@@ -131,9 +134,9 @@ class Detector:
         return {self.source: data}, meta
 
 
-class AGIPD(Detector):
+class AGIPDModule(Detector):
     pulses = 64
-    modules = 16
+    modules = 1
     mod_y = 128
     mod_x = 512
     pixel_size = 0.2
@@ -162,6 +165,8 @@ class AGIPD(Detector):
         'status': 0,
     }
 
+class AGIPD(AGIPDModule):
+    modules = 16
 
 class LPD(Detector):
     pulses = 300

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -310,7 +310,7 @@ def start_gen(port, ser='msgpack', version='2.2', detector='AGIPD',
             if msg == b'next':
                 train = next(generator)
                 msg = containize(train, ser, serialize, version)
-                socket.send_multipart(msg)
+                socket.send_multipart(msg, copy=False)
                 if debug:
                     print('Server : emitted train:',
                           train[1][list(train[1].keys())[0]]['timestamp.tid'])
@@ -365,7 +365,7 @@ class ServeInThread(Thread):
                     train = next(self.generator)
                     msg = containize(train, self.serialization_fmt,
                                      self.serialize, self.protocol_version)
-                    self.server_socket.send_multipart(msg)
+                    self.server_socket.send_multipart(msg, copy=False)
                 else:
                     print('Unrecognised request:', msg)
             elif self.stopper_r in events:

--- a/karabo_bridge/tests/conftest.py
+++ b/karabo_bridge/tests/conftest.py
@@ -8,7 +8,7 @@ from karabo_bridge.simulation import ServeInThread
 def sim_server():
     with TemporaryDirectory() as td:
         endpoint = "ipc://{}/server".format(td)
-        with ServeInThread(endpoint):
+        with ServeInThread(endpoint, detector='AGIPDModule'):
             yield endpoint
 
 
@@ -16,7 +16,7 @@ def sim_server():
 def sim_server_pickle():
     with TemporaryDirectory() as td:
         endpoint = "ipc://{}/server".format(td)
-        with ServeInThread(endpoint, ser='pickle'):
+        with ServeInThread(endpoint, detector='AGIPDModule', ser='pickle'):
             yield endpoint
 
 
@@ -24,5 +24,5 @@ def sim_server_pickle():
 def sim_server_version_1():
     with TemporaryDirectory() as td:
         endpoint = "ipc://{}/server".format(td)
-        with ServeInThread(endpoint, protocol_version='1.0'):
+        with ServeInThread(endpoint, detector='AGIPDModule', protocol_version='1.0'):
             yield endpoint

--- a/karabo_bridge/tests/test_client.py
+++ b/karabo_bridge/tests/test_client.py
@@ -9,15 +9,15 @@ from karabo_bridge import Client
 def test_get_frame(sim_server):
     c = Client(sim_server)
     data, metadata = c.next()
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in data
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in metadata
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in data
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in metadata
 
 
 def test_protocol_1(sim_server_version_1):
     c = Client(sim_server_version_1)
     data, metadata = c.next()
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in data
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in metadata
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in data
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in metadata
     assert all('metadata' in src for src in data.values())
 
 
@@ -31,20 +31,20 @@ def test_pickle(sim_server_pickle):
     data, metadata = c.next()
     assert isinstance(data, dict)
     assert isinstance(metadata, dict)
-    image = data['SPB_DET_AGIPD1M-1/DET/detector']['image.data']
+    image = data['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['image.data']
     assert isinstance(image, np.ndarray)
 
 
 def test_context_manager(sim_server):
     with Client(sim_server) as c:
         data, metadata = c.next()
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in data
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in metadata
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in data
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in metadata
     assert c._context.closed
 
 
 def test_iterator(sim_server):
     c = Client(sim_server)
     for i, (data, metadata) in enumerate(islice(c, 3)):
-        trainId = metadata['SPB_DET_AGIPD1M-1/DET/detector']['timestamp.tid']
+        trainId = metadata['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['timestamp.tid']
         assert trainId == 10000000000 + i

--- a/karabo_bridge/tests/test_glimpse.py
+++ b/karabo_bridge/tests/test_glimpse.py
@@ -9,7 +9,7 @@ from karabo_bridge.cli import glimpse
 def test_main(sim_server, capsys):
     glimpse.main([sim_server])
     out, err = capsys.readouterr()
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in out
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in out
 
 
 def test_save(sim_server):
@@ -20,5 +20,5 @@ def test_save(sim_server):
         assert len(files) == 1
         path = os.path.join(td, files[0])
         with h5py.File(path, 'r') as f:
-            trainId = f['SPB_DET_AGIPD1M-1/DET/detector/trainId'].value
+            trainId = f['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf/trainId'].value
             assert trainId == 10000000000

--- a/karabo_bridge/tests/test_monitor.py
+++ b/karabo_bridge/tests/test_monitor.py
@@ -4,4 +4,4 @@ from karabo_bridge.cli import monitor
 def test_main(sim_server, capsys):
     monitor.main([sim_server, '--ntrains', '1'])
     out, err = capsys.readouterr()
-    assert 'SPB_DET_AGIPD1M-1/DET/detector' in out
+    assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in out

--- a/karabo_bridge/tests/test_simulation.py
+++ b/karabo_bridge/tests/test_simulation.py
@@ -4,7 +4,7 @@ from karabo_bridge.simulation import Detector
 
 
 source_lpd = 'FXE_DET_LPD1M-1/DET/detector'
-source_spb = 'SPB_DET_AGIPD1M-1/DET/detector'
+source_spb_module = 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'
 train_id = 10000000000
 
 
@@ -21,11 +21,11 @@ def test_lpd():
     
 
 def test_gen():
-    agipd = Detector.getDetector('AGIPD', gen='zeros')
+    agipd = Detector.getDetector('AGIPDModule', gen='zeros')
     data, meta = agipd.gen_data(train_id)
 
     assert len(data) == len(meta) == 1
-    assert source_spb in data
-    assert meta[source_spb]['timestamp.tid'] == train_id
-    assert data[source_spb]['image.data'].shape == (16, 128, 512, 64)
-    assert not np.any(data[source_spb]['image.data'])
+    assert source_spb_module in data
+    assert meta[source_spb_module]['timestamp.tid'] == train_id
+    assert data[source_spb_module]['image.data'].shape == (1, 128, 512, 64)
+    assert not np.any(data[source_spb_module]['image.data'])


### PR DESCRIPTION
This avoids copying the big detector array when the simulator sends the message. There's a size threshold of 64 KB, so smaller messages will still be sent by copying memory as normal.

This reduces the time spent in `send_multipart` by around three orders of magnitude (~200ms to ~200µs) . I suspect there's some platform-level optimisation when we use `np.zeros()` that mean the memory is never really accessed at all.

(This came from investigating #43)