### PR TITLE
Simulator: measure and print rate every 50 trains sent

### DIFF
--- a/karabo_bridge/cli/simulation.py
+++ b/karabo_bridge/cli/simulation.py
@@ -36,6 +36,10 @@ def main(argv=None):
         '-g', '--gen', default='random', choices=['random', 'zeros'],
         help='Generator function to generate simulated detector data'
     )
+    ap.add_argument(
+        '--debug', action='store_true',
+        help='More verbose terminal logging'
+    )
     args = ap.parse_args(argv)
     start_gen(args.port, args.serialisation, args.protocol, args.detector,
-              args.corrected, args.nsources, args.gen)
+              args.corrected, args.nsources, args.gen, debug=args.debug)

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -265,6 +265,7 @@ def containize(train_data, ser, ser_func, vers):
 
     return msg
 
+TIMING_INTERVAL = 50
 
 def start_gen(port, ser='msgpack', version='2.2', detector='AGIPD',
               corrected=True, nsources=1, datagen='random', *, debug=True):
@@ -309,6 +310,9 @@ def start_gen(port, ser='msgpack', version='2.2', detector='AGIPD',
     print('Simulated Karabo-bridge server started on:\ntcp://{}:{}'.format(
           uname().nodename, port))
 
+    t_prev = time()
+    n = 0
+
     try:
         while True:
             msg = socket.recv()
@@ -319,6 +323,13 @@ def start_gen(port, ser='msgpack', version='2.2', detector='AGIPD',
                 if debug:
                     print('Server : emitted train:',
                           train[1][list(train[1].keys())[0]]['timestamp.tid'])
+                n += 1
+                if n % TIMING_INTERVAL == 0:
+                    t_now = time()
+                    print("Sent {} trains in {:.2f} seconds ({:.2f} Hz)".format(
+                        TIMING_INTERVAL, t_now - t_prev, TIMING_INTERVAL / (t_now - t_prev)
+                    ))
+                    t_prev = t_now
             else:
                 print('wrong request')
                 break


### PR DESCRIPTION
This makes it easier to see how quickly a user tool is getting data; run it against the simulator and get messages like this:

```
Sent 50 trains in 7.48 seconds (6.69 Hz)
```

It may also be useful for evaluating changes in the simulator and the bridge protocol.