### PR TITLE
Small refactoring

### DIFF
--- a/karabo_bridge/client.py
+++ b/karabo_bridge/client.py
@@ -20,6 +20,9 @@ import zmq
 __all__ = ['Client']
 
 
+CONTEXT = zmq.Context()
+
+
 class Client:
     """Karabo bridge client for Karabo pipeline data.
 
@@ -38,6 +41,8 @@ class Client:
         server socket you want to connect to (only support TCP socket).
     sock : str, optional
         socket type - supported: REQ, SUB.
+    context : zmq.Context
+        To run the Client's sockets using a provided ZeroMQ context.
     timeout : int
         Timeout on :method:`next` (in seconds)
 
@@ -55,9 +60,9 @@ class Client:
     ZMQError
         if provided endpoint is not valid.
     """
-    def __init__(self, endpoint, sock='REQ', timeout=None):
+    def __init__(self, endpoint, sock='REQ', context=None, timeout=None):
 
-        self._context = zmq.Context()
+        self._context = context or CONTEXT
         self._socket = None
 
         if sock == 'REQ':
@@ -136,7 +141,7 @@ class Client:
                 array = np.frombuffer(payload.buffer, dtype=dtype).reshape(shape)
                 data[source].update({md['path']: array})
             else:
-                raise RuntimeError('Unknown message content:', md['content'])
+                raise RuntimeError('Unknown message: %s' % md['content'])
         return data, meta
 
     def __enter__(self):

--- a/karabo_bridge/client.py
+++ b/karabo_bridge/client.py
@@ -19,9 +19,6 @@ import zmq
 __all__ = ['Client']
 
 
-CONTEXT = zmq.Context()
-
-
 class Client:
     """Karabo bridge client for Karabo pipeline data.
 
@@ -40,6 +37,9 @@ class Client:
         server socket you want to connect to (only support TCP socket).
     sock : str, optional
         socket type - supported: REQ, SUB.
+    ser : str, DEPRECATED
+        Serialization protocol to use to decode the incoming message (default
+        is msgpack) - supported: msgpack.
     context : zmq.Context
         To run the Client's sockets using a provided ZeroMQ context.
     timeout : int
@@ -59,9 +59,13 @@ class Client:
     ZMQError
         if provided endpoint is not valid.
     """
-    def __init__(self, endpoint, sock='REQ', context=None, timeout=None):
+    def __init__(self, endpoint, sock='REQ', ser='msgpack', timeout=None,
+                 context=None):
 
-        self._context = context or CONTEXT
+        if ser != 'msgpack':
+            raise Exception('Only serialization supported is msgpack')
+
+        self._context = context or zmq.Context()
         self._socket = None
 
         if sock == 'REQ':
@@ -147,7 +151,7 @@ class Client:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._socket.close(linger=0)
+        self._context.destroy(linger=0)
 
     def __iter__(self):
         return self

--- a/karabo_bridge/client.py
+++ b/karabo_bridge/client.py
@@ -62,7 +62,6 @@ class Client:
     def __init__(self, endpoint, sock='REQ', context=None, timeout=None):
 
         self._context = context or CONTEXT
-        print(type(self._context))
         self._socket = None
 
         if sock == 'REQ':

--- a/karabo_bridge/client.py
+++ b/karabo_bridge/client.py
@@ -62,6 +62,7 @@ class Client:
     def __init__(self, endpoint, sock='REQ', context=None, timeout=None):
 
         self._context = context or CONTEXT
+        print(type(self._context))
         self._socket = None
 
         if sock == 'REQ':
@@ -112,8 +113,8 @@ class Client:
         except zmq.error.Again:
             raise TimeoutError(
                 'No data received from {} in the last {} ms'.format(
-                self._socket.getsockopt_string(zmq.LAST_ENDPOINT),
-                self._socket.getsockopt(zmq.RCVTIMEO)))
+                    self._socket.getsockopt_string(zmq.LAST_ENDPOINT),
+                    self._socket.getsockopt(zmq.RCVTIMEO)))
         self._recv_ready = False
         return self._deserialize(msg)
 
@@ -147,7 +148,7 @@ class Client:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._context.destroy(linger=0)
+        self._socket.close(linger=0)
 
     def __iter__(self):
         return self

--- a/karabo_bridge/client.py
+++ b/karabo_bridge/client.py
@@ -10,7 +10,6 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
 from functools import partial
-import pickle
 
 import msgpack
 import numpy as np

--- a/karabo_bridge/client.py
+++ b/karabo_bridge/client.py
@@ -128,23 +128,15 @@ class Client:
             source = md['source']
             content = md['content']
 
-            if content in ('msgpack', 'pickle.HIGHEST_PROTOCOL',
-                           'pickle.DEFAULT_PROTOCOL'):
+            if content == 'msgpack':
                 data[source] = self.unpack(payload.bytes)
                 meta[source] = md.get('metadata', {})
-            elif content in ('array', 'ImageData'):
-                dtype = md['dtype']
-                shape = md['shape']
-
+            elif content == 'array':
+                dtype, shape = md['dtype'], md['shape']
                 array = np.frombuffer(payload.buffer, dtype=dtype).reshape(shape)
-
-                if content == 'array':
-                    data[source].update({md['path']: array})
-                else:
-                    data[source].update({md['path']: md['params']})
-                    data[source][md['path']]['Data'] = array
+                data[source].update({md['path']: array})
             else:
-                raise RuntimeError('unknown message content:', md['content'])
+                raise RuntimeError('Unknown message content:', md['content'])
         return data, meta
 
     def __enter__(self):

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -97,7 +97,6 @@ class Detector:
         else:
             return (self.modules, self.mod_y, self.mod_x, self.pulses)
 
-
     def random(self):
         return np.random.uniform(low=1500, high=1600,
                                  size=self.data_shape).astype(self.data_type)
@@ -319,10 +318,9 @@ def start_gen(port, ser='msgpack', version='2.2', detector='AGIPD',
                 n += 1
                 if n % TIMING_INTERVAL == 0:
                     t_now = time()
-                    print("Sent {} trains in {:.2f} seconds ({:.2f} Hz)".format(
-                        TIMING_INTERVAL, t_now - t_prev,
-                        TIMING_INTERVAL / (t_now - t_prev)
-                    ))
+                    print('Sent {} trains in {:.2f} seconds ({:.2f} Hz)'
+                          ''.format(TIMING_INTERVAL, t_now - t_prev,
+                                    TIMING_INTERVAL / (t_now - t_prev)))
                     t_prev = t_now
             else:
                 print('wrong request')

--- a/karabo_bridge/simulation.py
+++ b/karabo_bridge/simulation.py
@@ -289,13 +289,9 @@ def start_gen(port, ser='msgpack', version='2.2', detector='AGIPD',
     socket.setsockopt(zmq.LINGER, 0)
     socket.bind('tcp://*:{}'.format(port))
 
-    if ser == 'msgpack':
-        serialize = partial(msgpack.dumps, use_bin_type=True)
-    elif ser == 'pickle':
-        serialize = pickle.dumps
-        ser = 'pickle.DEFAULT_PROTOCOL'
-    else:
+    if ser != 'msgpack':
         raise ValueError("Unknown serialisation format %s" % ser)
+    serialize = partial(msgpack.dumps, use_bin_type=True)
     det = Detector.getDetector(detector, raw=raw, gen=datagen)
     generator = generate(det, nsources)
 
@@ -340,13 +336,9 @@ class ServeInThread(Thread):
         self.protocol_version = protocol_version
 
         self.serialization_fmt = ser
-        if ser == 'msgpack':
-            self.serialize = partial(msgpack.dumps, use_bin_type=True)
-        elif ser == 'pickle':
-            self.serialize = pickle.dumps
-            self.serialization_fmt = 'pickle.DEFAULT_PROTOCOL'
-        else:
+        if ser != 'msgpack':
             raise ValueError("Unknown serialisation format %s" % ser)
+        self.serialize = partial(msgpack.dumps, use_bin_type=True)
 
         det = Detector.getDetector(detector, raw=raw, gen=datagen)
         self.generator = generate(det, nsources)

--- a/karabo_bridge/tests/conftest.py
+++ b/karabo_bridge/tests/conftest.py
@@ -13,15 +13,6 @@ def sim_server():
 
 
 @pytest.fixture
-def sim_server_pickle():
-    with TemporaryDirectory() as td:
-        endpoint = "ipc://{}/server".format(td)
-        with ServeInThread(endpoint, detector='AGIPDModule',
-                           raw=True, ser='pickle'):
-            yield endpoint
-
-
-@pytest.fixture
 def sim_server_version_1():
     with TemporaryDirectory() as td:
         endpoint = "ipc://{}/server".format(td)

--- a/karabo_bridge/tests/test_client.py
+++ b/karabo_bridge/tests/test_client.py
@@ -31,7 +31,7 @@ def test_context_manager(sim_server):
         data, metadata = c.next()
     assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in data
     assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in metadata
-    assert c._context.closed
+    assert c._socket.closed
 
 
 def test_iterator(sim_server):

--- a/karabo_bridge/tests/test_client.py
+++ b/karabo_bridge/tests/test_client.py
@@ -26,15 +26,6 @@ def test_pull_socket(sim_server):
         c = Client(sim_server, sock='PULL')
 
 
-def test_pickle(sim_server_pickle):
-    c = Client(sim_server_pickle, ser='pickle')
-    data, metadata = c.next()
-    assert isinstance(data, dict)
-    assert isinstance(metadata, dict)
-    image = data['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['image.data']
-    assert isinstance(image, np.ndarray)
-
-
 def test_context_manager(sim_server):
     with Client(sim_server) as c:
         data, metadata = c.next()

--- a/karabo_bridge/tests/test_simulation.py
+++ b/karabo_bridge/tests/test_simulation.py
@@ -11,14 +11,14 @@ train_id = 10000000000
 def test_lpd():
     lpd = Detector.getDetector('LPD')
     data, meta = lpd.gen_data(train_id)
-    
+
     assert len(data) == len(meta) == 1
     assert source_lpd in data
     assert meta[source_lpd]['timestamp.tid'] == train_id
     img = data[source_lpd]['image.data']
     assert img.shape == (16, 256, 256, 300)
     assert not np.any(img[(img<1500) | (img>1600)])
-    
+
 
 def test_gen():
     agipd = Detector.getDetector('AGIPDModule', gen='zeros', raw=True)


### PR DESCRIPTION
This removed some deprecated implementation details, and small changes:
- remove support for pickle serialization (support is already dropped on server side)
- remove 'ImageData' messages
- add context argument or use the same `zmq.Context` for all `Client` instances in the same process
- fix some exception strings.
- pep8 fixes...