### PR TITLE
Fix: checking for equality

### DIFF
--- a/karabo_bridge/server.py
+++ b/karabo_bridge/server.py
@@ -54,7 +54,7 @@ class Sender:
             self.stopper_r.recv()
             return True
 
-        if events[self.server_socket] is zmq.POLLIN:
+        if events[self.server_socket] == zmq.POLLIN:
             msg = self.server_socket.recv()
             if msg != b'next':
                 print(f'Unrecognised request: {msg}')


### PR DESCRIPTION
pyzmq [23.0.0](https://pyzmq.readthedocs.io/en/latest/changelog.html#id1) uses enums for constants instead of ints.

