### PR TITLE
Add client for integration with Qt GUI code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache APT Packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.3.0
+      with:
+        packages: xvfb
+
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
@@ -35,7 +40,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python3 -m pytest -v --cov=karabo_bridge
+        xvfb-run python3 -m pytest -v --cov=karabo_bridge
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Cache APT Packages
-      uses: awalsh128/cache-apt-pkgs-action@v1.3.0
-      with:
-        packages: xvfb
-
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
@@ -40,9 +35,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        export QT_QPA_PLATFORM=offscreen
-        export QT_DEBUG_PLUGINS=1
-        python3 -m pytest -vs --cov=karabo_bridge
+        export QT_QPA_PLATFORM=offscreen  # No GUI required
+        python3 -m pytest -v --cov=karabo_bridge
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,9 @@ jobs:
 
     - name: Test with pytest
       run: |
+        export QT_QPA_PLATFORM=offscreen
         export QT_DEBUG_PLUGINS=1
-        xvfb-run python3 -m pytest -vs --cov=karabo_bridge
+        python3 -m pytest -vs --cov=karabo_bridge
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        xvfb-run python3 -m pytest -v --cov=karabo_bridge
+        export QT_DEBUG_PLUGINS=1
+        xvfb-run python3 -m pytest -vs --cov=karabo_bridge
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/karabo_bridge/qt.py
+++ b/karabo_bridge/qt.py
@@ -59,6 +59,17 @@ class Worker(QThread):
 
 
 class QBridgeClient(QObject):
+    """Karabo bridge client for use in Qt applications
+
+    Set this up pointing to an endpoint address which is sending Karabo bridge
+    data. This is in a format like 'tcp://localhost:45200'.
+    Connect to the new_data signal, which is emitted with the data & metadata
+    dictionaries for each message received. Then call .start() to receive data,
+    either for a set number of trains or until you call .stop().
+
+    This uses a thread, which can cause crashes if you close the application
+    while it's still running. You should call .stop() before it is deleted.
+    """
     worker = None
     ctrl_endpoint = None
     _dequeuing = False

--- a/karabo_bridge/qt.py
+++ b/karabo_bridge/qt.py
@@ -101,7 +101,6 @@ class QBridgeClient(QObject):
             stop_after=stop_after, parent=self,
         )
         worker.data_queued.connect(self._start_dequeueing)
-        worker.finished.connect(worker.deleteLater)
         worker.finished.connect(self._worker_finished)
         worker.start()
 
@@ -149,5 +148,6 @@ class QBridgeClient(QObject):
                 break
 
     def _worker_finished(self):
+        self.worker.deleteLater()
         self.worker = None
         self.stopped.emit()

--- a/karabo_bridge/qt.py
+++ b/karabo_bridge/qt.py
@@ -63,7 +63,7 @@ class QBridgeClient(QObject):
     ctrl_endpoint = None
     _dequeuing = False
 
-    new_data = Signal(object, object)
+    new_data = Signal(dict, dict)
     stopped = Signal()
 
     def __init__(self, endpoint, sock='REQ', parent=None):

--- a/karabo_bridge/qt_client.py
+++ b/karabo_bridge/qt_client.py
@@ -1,0 +1,136 @@
+import queue
+from itertools import count
+from secrets import token_hex
+
+import zmq
+from qtpy.QtCore import QObject, QThread, QTimer, Signal, Slot
+
+from .serializer import deserialize
+
+class Worker(QThread):
+    data_queued = Signal()
+
+    def __init__(self, endpoint, sock_type, ctrl_endpoint, stop_after=0,
+                 parent=None):
+        super().__init__(parent)
+        self.endpoint = endpoint
+        self.sock_type = sock_type
+        self.ctrl_endpoint = ctrl_endpoint
+        self.stop_after = stop_after
+        self.queue = queue.Queue(maxsize=5)
+
+    def run(self):
+        ctx = zmq.Context.instance()
+        data_sock = ctx.socket(self.sock_type)
+        data_sock.connect(self.endpoint)
+        if self.sock_type == zmq.SUB:
+            data_sock.setsockopt(zmq.SUBSCRIBE, b'')
+        ctrl_sock = ctx.socket(zmq.PULL)
+        ctrl_sock.bind(self.ctrl_endpoint)
+
+        poller = zmq.Poller()
+        poller.register(data_sock, zmq.POLLIN)
+        poller.register(ctrl_sock, zmq.POLLIN)
+
+        if self.sock_type == zmq.REQ:
+            data_sock.send(b'next')
+
+        for i in count():
+            ready = [sock for (sock, _) in poller.poll()]
+            if ctrl_sock in ready:
+                _ = ctrl_sock.recv()
+                break
+
+
+            if data_sock in ready:
+                raw_msgs = data_sock.recv_multipart(copy=False)
+                data, metadata = deserialize(raw_msgs)
+                self.queue.put((data, metadata))
+                self.data_queued.emit()
+                if (self.stop_after > 0) and (i >= self.stop_after):
+                    break
+
+            if self.sock_type == zmq.REQ:
+                data_sock.send(b'next')
+
+        # Stop receiving
+        ctrl_sock.close()
+        data_sock.close()
+
+
+class QBridgeClient(QObject):
+    worker = None
+    ctrl_endpoint = None
+    _dequeuing = False
+
+    new_data = Signal(object, object)
+    stopped = Signal()
+
+    def __init__(self, endpoint, sock='REQ', parent=None):
+        super().__init__(parent)
+        self.endpoint = endpoint
+        if sock not in {'REQ', 'PULL', 'SUB'}:
+            raise ValueError("sock must be 'REQ', 'PULL' or 'SUB'")
+        self.sock_type = getattr(zmq, sock)
+
+    def start(self, stop_after=0):
+        if self.worker is not None:
+            raise RuntimeError("QBridgeClient is already running")
+        self.ctrl_endpoint = f'inproc://{token_hex(20)}'
+        self.worker = worker = Worker(
+            self.endpoint, self.sock_type, self.ctrl_endpoint, stop_after, parent=self,
+        )
+        worker.data_queued.connect(self._start_dequeueing)
+        worker.finished.connect(worker.deleteLater)
+        worker.finished.connect(self._worker_finished)
+        worker.start()
+
+    @property
+    def is_active(self):
+        return self.worker is not None
+
+    # Sending received data as signals from the thread causes issues if they
+    # are emitted faster than they are processed. This mechanism uses a bounded
+    # queue to limit how much data is buffered, and uses QTimer to pull data
+    # out of the queue and turn it into signals in cooperation with the event
+    # loop. User code should be able to connect to the new_data signal without
+    # knowing about this.
+    @Slot()
+    def _start_dequeueing(self):
+        if not self._dequeuing:
+            self._dequeuing = True
+            QTimer.singleShot(0, self._dequeue_one)
+
+    def _dequeue_one(self):
+        if self.worker is None:
+            self._dequeuing = False
+            return
+
+        try:
+            data, metadata = self.worker.queue.get_nowait()
+        except queue.Empty:
+            self._dequeuing = False
+            return
+
+        self.new_data.emit(data, metadata)
+        QTimer.singleShot(0, self._dequeue_one)
+
+    def stop(self):
+        if self.worker is None:
+            return
+
+        ctx = zmq.Context.instance()
+        ctrl_sock = ctx.socket(zmq.PUSH)
+        ctrl_sock.connect(self.ctrl_endpoint)
+        ctrl_sock.send(b'stop')
+        ctrl_sock.close()
+        # Drain the queue to ensure the worker isn't stuck in .put()
+        while True:
+            try:
+                self.worker.queue.get_nowait()
+            except queue.Empty:
+                break
+
+    def _worker_finished(self):
+        self.worker = None
+        self.stopped.emit()

--- a/karabo_bridge/qt_client.py
+++ b/karabo_bridge/qt_client.py
@@ -35,7 +35,7 @@ class Worker(QThread):
         if self.sock_type == zmq.REQ:
             data_sock.send(b'next')
 
-        for i in count():
+        for i in count(start=1):
             ready = [sock for (sock, _) in poller.poll()]
             if ctrl_sock in ready:
                 _ = ctrl_sock.recv()

--- a/karabo_bridge/qt_client.py
+++ b/karabo_bridge/qt_client.py
@@ -73,7 +73,25 @@ class QBridgeClient(QObject):
             raise ValueError("sock must be 'REQ', 'PULL' or 'SUB'")
         self.sock_type = getattr(zmq, sock)
 
+    def set_endpoint(self, endpoint, sock='REQ'):
+        """Change the ZMQ socket to receive data from
+
+        If ``.start()`` was already called, you need to stop & start the client
+        again for this to take effect.
+        """
+        self.endpoint = endpoint
+        if sock not in {'REQ', 'PULL', 'SUB'}:
+            raise ValueError("sock must be 'REQ', 'PULL' or 'SUB'")
+        self.sock_type = getattr(zmq, sock)
+
     def start(self, stop_after=0):
+        """Start receiving data
+
+        Connect to the ``new_data`` signal to handle incoming data.
+
+        If stop_after > 0, it will automatically stop once N trains have been
+        received. Otherwise, it continues until ``.stop()`` is called.
+        """
         if self.worker is not None:
             raise RuntimeError("QBridgeClient is already running")
         self.ctrl_endpoint = f'inproc://{token_hex(20)}'
@@ -116,6 +134,7 @@ class QBridgeClient(QObject):
         QTimer.singleShot(0, self._dequeue_one)
 
     def stop(self):
+        """Stop receiving data"""
         if self.worker is None:
             return
 

--- a/karabo_bridge/tests/test_qt.py
+++ b/karabo_bridge/tests/test_qt.py
@@ -1,6 +1,6 @@
 from karabo_bridge.qt import QBridgeClient
 
-def test_receive_n(sim_server, qtbot):
+def test_receive_n(sim_server, qtbot, qapp):
     qbc = QBridgeClient(sim_server.endpoint)
     results = []
     def data_received(data, metadata):
@@ -10,6 +10,8 @@ def test_receive_n(sim_server, qtbot):
     with qtbot.waitSignal(qbc.stopped, timeout=5000):
         qbc.start(stop_after=2)
         assert qbc.is_active
+
+    qapp.processEvents()
 
     assert not qbc.is_active
 
@@ -21,6 +23,8 @@ def test_receive_n(sim_server, qtbot):
     # Check that we can start receiving again after stopping
     with qtbot.waitSignal(qbc.stopped, timeout=5000):
         qbc.start(stop_after=2)
+
+    qapp.processEvents()
 
     assert len(results) == 4
 

--- a/karabo_bridge/tests/test_qt.py
+++ b/karabo_bridge/tests/test_qt.py
@@ -1,0 +1,44 @@
+from karabo_bridge.qt import QBridgeClient
+
+def test_receive_n(sim_server, qtbot):
+    qbc = QBridgeClient(sim_server.endpoint)
+    results = []
+    def data_received(data, metadata):
+        results.append((data, metadata))
+    qbc.new_data.connect(data_received)
+
+    with qtbot.waitSignal(qbc.stopped, timeout=5000):
+        qbc.start(stop_after=2)
+        assert qbc.is_active
+
+    assert not qbc.is_active
+
+    assert len(results) == 2
+    for data, metadata in results:
+        assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in data
+        assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in metadata
+
+    # Check that we can start receiving again after stopping
+    with qtbot.waitSignal(qbc.stopped, timeout=5000):
+        qbc.start(stop_after=2)
+
+    assert len(results) == 4
+
+
+def test_receive_indefinite(sim_server, qtbot):
+    qbc = QBridgeClient(sim_server.endpoint)
+    n_recvd = 0
+    def data_received(data, metadata):
+        nonlocal n_recvd
+        n_recvd += 1
+        if n_recvd >= 5:
+            qbc.stop()
+
+    qbc.new_data.connect(data_received)
+
+    with qtbot.waitSignal(qbc.stopped, timeout=5000):
+        qbc.start()
+
+    assert not qbc.is_active
+
+    assert n_recvd == 5

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(name="karabo_bridge",
               'pytest-qt',
               'h5py',
               'testpath',
+              'QtPy',
+              'PyQt5',
           ]
       },
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name="karabo_bridge",
           'test': [
               'pytest',
               'pytest-cov',
+              'pytest-qt',
               'h5py',
               'testpath',
           ]

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(name="karabo_bridge",
           'pyzmq>=17.0.0',
       ],
       extras_require={
+          'qt': ['QtPy'],
           'test': [
               'pytest',
               'pytest-cov',


### PR DESCRIPTION
The existing client class is good for scripting but tricky for GUI code, because it blocks and the obvious way to use it is in a loop, meaning more blocking. Qt is often used to create simple GUIs, so I thought it was worth making a client that plays nicely with that. I wrote this for Yohei during this past run; he says that it's useful, though I don't think it's been tested as much as I had hoped.

I'm expecting controversy on at least two points:

1. Should this exist at all? We don't generally encourage people to write their own GUIs, because the code is a lot more complex than scripts/notebooks doing similar analysis, and if they want GUIs with online data, they could write a Metro context file or even a Karabo device. However, at least some people want to make custom GUIs anyway, e.g. because they're not happy with the plotting options in Metro & Karabo, and I'd rather give them some reasonable way to do that. We could maintain it but not advertise it. :shrug: 
2. What's going on with the signals, queue and timer? The `QBridgeClient.new_data` signal is what user code should use. But if I just fire these off as soon as the worker thread gets data, and the code doesn't handle them fast enough, you get a backlog of pending signals, which other signals, like mouse clicks, get bogged down in :-1: . The Queue and the QTimer let us pace the data so the application stays responsive and memory usage doesn't blow up, but whenever both the application and the data are ready, processing can begin with minimal delay. :crossed_fingers: 

There's an example of some code using it (from a real use case, not totally cleaned up) at: https://git.xfel.eu/kluyvert/xes_photoncounting_p4936/-/blob/main/XES_plot_pc.py