### PR TITLE
walk_dict_to_hdf5: Explicitly use np.int64

### DIFF
--- a/karabo_bridge/cli/glimpse.py
+++ b/karabo_bridge/cli/glimpse.py
@@ -59,8 +59,10 @@ def walk_dict_to_hdf5(dic, h5):
             walk_dict_to_hdf5(value, group)
         elif isinstance(value, (np.ndarray)):
             h5.create_dataset(key, data=value, dtype=value.dtype)
-        elif isinstance(value, (int, float)):
-            h5.create_dataset(key, data=value, dtype=type(value))
+        elif isinstance(value, int):
+            h5.create_dataset(key, data=value, dtype=np.int64)
+        elif isinstance(value, float):
+            h5.create_dataset(key, data=value, dtype=np.float64)
         elif isinstance(value, str):
             # VLEN strings do not support embedded NULLs
             value = value.replace('\x00', '')


### PR DESCRIPTION
`dtype=float` is equivalent to `dtype=np.float64`, but `dtype=int` is equivalent to `dtype=np.int_`, which is 32 bits wide on 32-bit systems and not necessarily wide enough for the data we're trying to convert. As shown (sort of) in https://bugs.debian.org/1103147, this caused test failures on 32-bit architectures.