### PR TITLE
Update minimum Python version to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name="karabo_bridge",
                    "system."),
       long_description=read("README.rst"),
       license="BSD-3-Clause",
-      python_requires=">=3.7",
+      python_requires=">=3.10",
       install_requires=[
           'msgpack>=0.5.4',
           'msgpack-numpy',


### PR DESCRIPTION
In line with our other packages. Fixes CI by removing older Python versions which are no longer on the `ubuntu-latest` image.